### PR TITLE
Fix: `create_line()` vertical axis label 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,9 +8,10 @@ The changes made in this PR are:
 
 
 # Checks
-- [ ] All R CMD checks pass 
+- [ ] All R CMD checks pass.
 - [ ] `roxygen2::roxygenise()` has been run prior to merging to ensure that `.Rd` and `NAMESPACE` files are up to date.
 - [ ] `NEWS.md` has been updated.
+- [ ] If a new version is required, create a new version with `usethis::use_version()`.
 
 # Notes
 This fixes #<issue_number>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: vivainsights
 Type: Package
 Title: Analyze and Visualize Data from 'Microsoft Viva Insights'
-Version: 0.5.1
+Version: 0.5.2
 Authors@R: c(
     person(given = "Martin", family = "Chan", role = c("aut", "cre"), email = "martin.chan@microsoft.com"),
     person(given = "Carlos", family = "Morales", role = "aut", email = "carlos.morales@microsoft.com")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# vivainsights 0.5.2
+
+Minor bugfix on `create_line()`. 
+
 # vivainsights 0.5.1
 
 Minor changes to documentation on static report outputs.

--- a/R/create_line.R
+++ b/R/create_line.R
@@ -79,14 +79,21 @@ create_line <- function(data,
   data %>%
     check_inputs(requirements = required_variables)
 
+  ## Clean metric name
+  clean_nm <- us_to_space(metric)
+  
   ## Handling NULL values passed to hrvar
   if(is.null(hrvar)){
     data <- totals_col(data)
     hrvar <- "Total"
-  }
-
-  ## Clean metric name
-  clean_nm <- us_to_space(metric)
+    subtitle_nm <- paste("Total",
+                         tolower(clean_nm),"over time")
+    } else{
+    subtitle_nm <- paste("Total",
+                         tolower(clean_nm),
+                         "by",
+                         tolower(camel_clean(hrvar)))
+    }
 
   myTable <-
     data %>%
@@ -101,7 +108,7 @@ create_line <- function(data,
     myTable %>%
     group_by(MetricDate, group) %>%
     summarize(Employee_Count = mean(Employee_Count),
-              !!sym(metric) := mean(!!sym(metric)))
+              !!sym(metric) := mean(!!sym(metric)),.groups = "drop")
 
   ## Data frame to return
   myTable_return <-
@@ -132,12 +139,9 @@ create_line <- function(data,
                                       colour = "#FFFFFF",
                                       face = "bold")) +
       labs(title = clean_nm,
-           subtitle = paste("Total",
-                            tolower(clean_nm),
-                            "by",
-                            tolower(camel_clean(hrvar))),
-           x = "MetricDate",
-           y = "Weekly hours",
+           subtitle = subtitle_nm,
+           x = "Metric Date",
+           y = clean_nm,
            caption = extract_date_range(data, return = "text")) +
       ylim(0, NA) # Set origin to zero
 


### PR DESCRIPTION
# Summary

This branch fixes `create_line()`, where in its plot output, it assumes that the vertical axis will represent 'Weekly hours'. The solution is to make it customised to the metric provided to the function. This issue is detailed in #28. 

This PR also pushes the patch version `v0.5.2` to CRAN. 

# Changes
1. Changes in labs 'x' and 'y' axis to fix assumption in `create_line()` function for '_Weekly hours_' Label
2. Changes in _NULL_ handling to `hrvar`. When NULL is passed, a different subtitle label is used. 
3. Changes in `summarize(.groups = "drop")` to avoid unwanted dplyr messages. 
4. Increment version to `v0.5.2`


<img width="559" alt="image" src="https://github.com/microsoft/vivainsights/assets/56433553/2f03a357-1ea4-4d38-a716-964831b967f7">

# Example

The following code is used for testing. 

```R
library(vivainsights)

# vertical axis shows actual metric value, i.e. 'Meetings'
pq_data %>%
  create_line(
    hrvar = 'Organization',
    metric = 'Meetings'
  )

# Subtitle shows 'Total meetings over time' 
pq_data %>%
  create_line(
    hrvar = NULL,
    metric = 'Meetings'
  )
```


# Checks
- [ ] All R CMD checks pass 
- [ ] `roxygen2::roxygenise()` has been run prior to merging to ensure that `.Rd` and `NAMESPACE` files are up to date.
- [x] `NEWS.md` has been updated.

# Notes
This fixes #28.
